### PR TITLE
Use correct arg for word count, terminate normally after script has finished

### DIFF
--- a/WordGenerator/main.cpp
+++ b/WordGenerator/main.cpp
@@ -29,7 +29,4 @@ int main(int argc, char **argv) {
 
 	for (int i = 0; i < word_count; i++)
 		std::cout << gen.nextNew() << std::endl;
-	
-	int pause;
-	std::cin >> pause;
 }

--- a/WordGenerator/main.cpp
+++ b/WordGenerator/main.cpp
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
 
 	gen.train(names);
 
-	int word_count = (argc == 0) ? 29 : std::atoi(argv[0]);
+	int word_count = (argc == 0) ? 29 : std::atoi(argv[1]);
 	if (word_count < 1)
 		word_count = 29;
 


### PR DESCRIPTION
argv[0] is always the script/executable filename. The word count is at argv[1].

I can't see a good reason for the program to pause instead of just terminating normally, so I have suggested removing that as well.